### PR TITLE
Updated podspec to includes sub spec for just ObjC

### DIFF
--- a/PMKVObserver.podspec
+++ b/PMKVObserver.podspec
@@ -15,8 +15,18 @@ PMKVObserver provides a safe block-based wrapper around Key-Value Observing, wit
   s.license      = { :type => "MIT", :file => "LICENSE-MIT" }
   s.author       = { "Kevin Ballard" => "kevin.ballard@postmates.com" }
   s.source       = { :git => "https://github.com/postmates/PMKVObserver.git", :tag => "v#{s.version}" }
-  s.source_files = "PMKVObserver"
   s.requires_arc = true
+
+
+  s.subspec 'ObjC' do |ss|
+    ss.source_files = 'PMKVObserver/**/*.{h,m}'
+  end
+
+  s.subspec 'Swift' do |ss|
+      ss.ios.deployment_target = '8.0'
+      ss.source_files = 'PMKVObserver/**/*.{swift}'
+      ss.dependency 'PMKVObserver/ObjC'
+  end
 
   s.ios.deployment_target = "8.0"
   s.osx.deployment_target = "10.9"

--- a/PMKVObserver.podspec
+++ b/PMKVObserver.podspec
@@ -19,11 +19,10 @@ PMKVObserver provides a safe block-based wrapper around Key-Value Observing, wit
 
 
   s.subspec 'ObjC' do |ss|
-    ss.source_files = 'PMKVObserver/**/*.{h,m}'
+      ss.source_files = 'PMKVObserver/**/*.{h,m}'
   end
 
   s.subspec 'Swift' do |ss|
-      ss.ios.deployment_target = '8.0'
       ss.source_files = 'PMKVObserver/**/*.{swift}'
       ss.dependency 'PMKVObserver/ObjC'
   end


### PR DESCRIPTION
The existing pod spec brings in the objective-c files and swift. If using this pods in a project which includes static libs then the pod can not be used as it contains swift and there has to be a framework. 

This PR includes a 2 subspaces one for ObjC and one for Swift. 

Example usage just for ObjC

```
      pod 'PMKVObserver/ObjC'
```
