### PR TITLE
Migrated codebase to swift 3.0 (Xcode 8 beta 2)

### DIFF
--- a/PMKVObserver.xcodeproj/project.pbxproj
+++ b/PMKVObserver.xcodeproj/project.pbxproj
@@ -165,14 +165,16 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0710;
-				LastUpgradeCheck = 0720;
+				LastUpgradeCheck = 0800;
 				ORGANIZATIONNAME = Postmates;
 				TargetAttributes = {
 					9EE8AAF01BFD5B9B00739406 = {
 						CreatedOnToolsVersion = 7.1.1;
+						LastSwiftMigration = 0800;
 					};
 					9EE8AAFA1BFD5B9B00739406 = {
 						CreatedOnToolsVersion = 7.1.1;
+						LastSwiftMigration = 0800;
 					};
 				};
 			};
@@ -341,6 +343,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
+				COMBINE_HIDPI_IMAGES = YES;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -353,6 +356,7 @@
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos macosx watchsimulator watchos appletvsimulator appletvos";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -360,6 +364,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
+				COMBINE_HIDPI_IMAGES = YES;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -371,6 +376,8 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos macosx watchsimulator watchos appletvsimulator appletvos";
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -379,6 +386,7 @@
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = NO;
 				CLANG_ENABLE_MODULES = YES;
+				COMBINE_HIDPI_IMAGES = YES;
 				INFOPLIST_FILE = PMKVObserverTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
@@ -386,6 +394,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos macosx";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -394,12 +403,15 @@
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = NO;
 				CLANG_ENABLE_MODULES = YES;
+				COMBINE_HIDPI_IMAGES = YES;
 				INFOPLIST_FILE = PMKVObserverTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.postmates.PMKVObserverTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos macosx";
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};

--- a/PMKVObserver.xcodeproj/xcshareddata/xcschemes/PMKVObserver.xcscheme
+++ b/PMKVObserver.xcodeproj/xcshareddata/xcschemes/PMKVObserver.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0720"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/PMKVObserver/KVObserver.h
+++ b/PMKVObserver/KVObserver.h
@@ -50,19 +50,19 @@ __attribute__((objc_subclassing_restricted))
 @interface PMKVObserver : NSObject
 /// Establishes a KVO relationship to <tt>object</tt>. The KVO will be active until \c object deallocates or
 /// until the \c cancel() method is invoked.
-+ (instancetype)observeObject:(id)object keyPath:(NSString *)keyPath options:(NSKeyValueObservingOptions)options block:(void (^)(id object, NSDictionary<NSString *,id> * _Nullable change, PMKVObserver *kvo))block NS_SWIFT_UNAVAILABLE("use init(object:keyPath:options:block:)");
++ (instancetype)observeObject:(id)object keyPath:(NSString *)keyPath options:(NSKeyValueObservingOptions)options block:(void (^)(id object, NSDictionary<NSKeyValueChangeKey,id> * _Nullable change, PMKVObserver *kvo))block NS_SWIFT_UNAVAILABLE("use init(object:keyPath:options:block:)");
 
 /// Establishes a KVO relationship to <tt>object</tt>. The KVO will be active until either \c object or
 /// \c observer deallocates or until the \c cancel() method is invoked.
-+ (instancetype)observeObject:(id)object observer:(id)observer keyPath:(NSString *)keyPath options:(NSKeyValueObservingOptions)options block:(void (^)(id observer, id object, NSDictionary<NSString *,id> * _Nullable change, PMKVObserver *kvo))block NS_SWIFT_UNAVAILABLE("use init(observer:object:keyPath:options:block:)");
++ (instancetype)observeObject:(id)object observer:(id)observer keyPath:(NSString *)keyPath options:(NSKeyValueObservingOptions)options block:(void (^)(id observer, id object, NSDictionary<NSKeyValueChangeKey,id> * _Nullable change, PMKVObserver *kvo))block NS_SWIFT_UNAVAILABLE("use init(observer:object:keyPath:options:block:)");
 
 /// Establishes a KVO relationship to <tt>object</tt>. The KVO will be active until \c object deallocates or
 /// until the \c cancel() method is invoked.
-- (instancetype)initWithObject:(id)object keyPath:(NSString *)keyPath options:(NSKeyValueObservingOptions)options block:(void (^)(id object, NSDictionary<NSString *,id> * _Nullable change, PMKVObserver *kvo))block NS_DESIGNATED_INITIALIZER NS_REFINED_FOR_SWIFT;
+- (instancetype)initWithObject:(id)object keyPath:(NSString *)keyPath options:(NSKeyValueObservingOptions)options block:(void (^)(id object, NSDictionary<NSKeyValueChangeKey,id> * _Nullable change, PMKVObserver *kvo))block NS_DESIGNATED_INITIALIZER NS_REFINED_FOR_SWIFT;
 
 /// Establishes a KVO relationship to <tt>object</tt>. The KVO will be active until either \c object or
 /// \c observer deallocates or until the \c cancel() method is invoked.
-- (instancetype)initWithObserver:(id)observer object:(id)object keyPath:(NSString *)keyPath options:(NSKeyValueObservingOptions)options block:(void (^)(id observer, id object, NSDictionary<NSString *,id> * _Nullable change, PMKVObserver *kvo))block NS_DESIGNATED_INITIALIZER NS_REFINED_FOR_SWIFT;
+- (instancetype)initWithObserver:(id)observer object:(id)object keyPath:(NSString *)keyPath options:(NSKeyValueObservingOptions)options block:(void (^)(id observer, id object, NSDictionary<NSKeyValueChangeKey,id> * _Nullable change, PMKVObserver *kvo))block NS_DESIGNATED_INITIALIZER NS_REFINED_FOR_SWIFT;
 
 - (instancetype)init NS_UNAVAILABLE;
 

--- a/PMKVObserver/KVObserver.m
+++ b/PMKVObserver/KVObserver.m
@@ -38,8 +38,8 @@ typedef NS_ENUM(uint_fast8_t, PMKVObserverState) {
     PMKVObserverStateDeregistered = 1 << 2
 };
 
-typedef void (^Callback)(id object, NSDictionary<NSString *,id> * _Nullable change, PMKVObserver *kvo);
-typedef void (^ObserverCallback)(id observer, id object, NSDictionary<NSString *,id> * _Nullable change, PMKVObserver *kvo);
+typedef void (^Callback)(id object, NSDictionary<NSKeyValueChangeKey,id> * _Nullable change, PMKVObserver *kvo);
+typedef void (^ObserverCallback)(id observer, id object, NSDictionary<NSKeyValueChangeKey,id> * _Nullable change, PMKVObserver *kvo);
 
 @implementation PMKVObserver {
     __weak id _Nullable _object;

--- a/PMKVObserver/KVObserver.swift
+++ b/PMKVObserver/KVObserver.swift
@@ -21,7 +21,7 @@ extension KVObserver {
     /// until the `cancel()` method is invoked.
     public convenience init<Object: AnyObject>(object: Object, keyPath: String, options: NSKeyValueObservingOptions = [], block: (object: Object, change: Change, kvo: KVObserver) -> Void) {
         self.init(__object: object, keyPath: keyPath, options: options, block: { (object, change, kvo) in
-            block(object: unsafeDowncast(object), change: Change(rawDict: change), kvo: kvo)
+            block(object: unsafeDowncast(object, to: Object.self), change: Change(rawDict: change), kvo: kvo)
         })
     }
     
@@ -29,7 +29,7 @@ extension KVObserver {
     /// deallocates or until the `cancel()` method is invoked.
     public convenience init<T: AnyObject, Object: AnyObject>(observer: T, object: Object, keyPath: String, options: NSKeyValueObservingOptions = [], block: (observer: T, object: Object, change: Change, kvo: KVObserver) -> Void) {
         self.init(__observer: observer, object: object, keyPath: keyPath, options: options, block: { (observer, object, change, kvo) in
-            block(observer: unsafeDowncast(observer), object: unsafeDowncast(object), change: Change(rawDict: change), kvo: kvo)
+            block(observer: unsafeDowncast(observer, to: T.self), object: unsafeDowncast(object, to: Object.self), change: Change(rawDict: change), kvo: kvo)
         })
     }
     
@@ -38,37 +38,37 @@ extension KVObserver {
         /// The kind of the change.
         /// - seealso: `NSKeyValueChangeKindKey`
         public var kind: NSKeyValueChange? {
-            return (self.rawDict?[NSKeyValueChangeKindKey] as? UInt).flatMap(NSKeyValueChange.init)
+            return (self.rawDict?[NSKeyValueChangeKey.kindKey] as? UInt).flatMap(NSKeyValueChange.init)
         }
         
         /// The old value from the change.
         /// - seealso: `NSKeyValueChangeOldKey`
         public var old: AnyObject? {
-            return self.rawDict?[NSKeyValueChangeOldKey]
+            return self.rawDict?[NSKeyValueChangeKey.oldKey]
         }
         
         /// The new value from the change.
         /// - seealso: `NSKeyValueChangeNewKey`
         public var new: AnyObject? {
-            return self.rawDict?[NSKeyValueChangeNewKey]
+            return self.rawDict?[NSKeyValueChangeKey.newKey]
         }
         
         /// Whether this callback is being sent prior to the change.
         /// - seealso: `NSKeyValueChangeNotificationIsPriorKey`
         public var isPrior: Bool {
-            return self.rawDict?[NSKeyValueChangeNotificationIsPriorKey] as? Bool ?? false
+            return self.rawDict?[NSKeyValueChangeKey.notificationIsPriorKey] as? Bool ?? false
         }
         
         /// The indexes of the inserted, removed, or replaced objects when relevant.
         /// - seealso: `NSKeyValueChangeIndexesKey`
-        public var indexes: NSIndexSet? {
-            return self.rawDict?[NSKeyValueChangeIndexesKey] as? NSIndexSet
+        public var indexes: IndexSet? {
+            return self.rawDict?[NSKeyValueChangeKey.indexesKey] as? IndexSet
         }
         
         /// The raw change dictionary passed to `observeValueForKeyPath(_:ofObject:change:context:)`.
-        public let rawDict: [String: AnyObject]?
+        public let rawDict: [NSKeyValueChangeKey: AnyObject]?
         
-        private init(rawDict: [String: AnyObject]?) {
+        private init(rawDict: [NSKeyValueChangeKey: AnyObject]?) {
             self.rawDict = rawDict
         }
     }
@@ -81,6 +81,6 @@ extension KVObserver {
     ///
     /// - Note: This property does not support key-value observing.
     @nonobjc public var isCancelled: Bool {
-        return __cancelled
+        return __isCancelled
     }
 }

--- a/PMKVObserverTests/KVObserverTests.swift
+++ b/PMKVObserverTests/KVObserverTests.swift
@@ -34,7 +34,7 @@ class KVObserverTests: XCTestCase {
         token = KVObserver(object: helper, keyPath: "str") { [weak helper] object, change, kvo in
             fired = true
             XCTAssert(object === helper)
-            XCTAssertEqual(change.kind, .Setting)
+            XCTAssertEqual(change.kind, .setting)
             XCTAssert(kvo === token)
             XCTAssertEqual(object.str, "foo")
         }
@@ -67,7 +67,7 @@ class KVObserverTests: XCTestCase {
         weak var weakToken: KVObserver!
         helper.str = "foo"
         autoreleasepool {
-            let token = KVObserver(object: helper, keyPath: "str", options: .Initial) { object, _, kvo in
+            let token = KVObserver(object: helper, keyPath: "str", options: .initial) { object, _, kvo in
                 fired = true
                 XCTAssertEqual(object.str, "foo")
                 kvo.cancel()
@@ -82,7 +82,7 @@ class KVObserverTests: XCTestCase {
         XCTAssertNil(weakToken)
         
         autoreleasepool {
-            let token = KVObserver(observer: self, object: helper, keyPath: "str", options: .Initial) { _, object, _, kvo in
+            let token = KVObserver(observer: self, object: helper, keyPath: "str", options: .initial) { _, object, _, kvo in
                 fired = true
                 XCTAssertEqual(object.str, "bar")
                 kvo.cancel()


### PR DESCRIPTION
@kballard 

Here's a fix for https://github.com/postmates/PMKVObserver/issues/10

Most of the migration work was done automatically with the Xcode migration tool. All I had to do is to play around with `NSKeyValueChangeKey` and `unsafeDowncast`.

All tests pass on both OSX and iOS.

I would suggest to merge this code in a new branch `swift-3.0` to keep the code separate until Xcode 8 is released.

Let me know if you have any questions!

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/postmates/pmkvobserver/11)

<!-- Reviewable:end -->
